### PR TITLE
Revert "Update Unifi Ingress to use http port and ImplementationSpecific PathType"

### DIFF
--- a/unifi/values.yaml
+++ b/unifi/values.yaml
@@ -6,9 +6,7 @@ unifi:
         - host: unifi.lucyscrib.com
           paths:
             - path: /
-              pathType: ImplementationSpecific
-              service:
-                port: 8080
+              pathType: Prefix
 
   mongodb:
     enabled: true


### PR DESCRIPTION
Reverts apt-itude/homelab-kubernetes#18

Turns out 8080 is used for something else and the UI is only exposed over 8443