### PR TITLE
Only make `lan` l2 advertisements from the `alpha` node

### DIFF
--- a/metallb/templates/l2-advertisement.yaml
+++ b/metallb/templates/l2-advertisement.yaml
@@ -5,3 +5,6 @@ metadata:
 spec:
   ipAddressPools:
     - lan
+  nodeSelectors:
+    - matchLabels:
+        kubernetes.io/hostname: alpha


### PR DESCRIPTION
Not sure yet why, but if `bravo` is used for advertisements for the traefik service, I get connection timeouts for all ingresses.