### PR TITLE
Add required node affinity to mongodb for amd64

### DIFF
--- a/apps/unifi/values.yaml
+++ b/apps/unifi/values.yaml
@@ -33,6 +33,12 @@ unifi:
     image:
       tag: 5.0.20-debian-11-r0
 
+    nodeAffinityPreset:
+      type: hard
+      key: kubernetes.io/arch
+      values:
+        - amd64
+
     persistence:
       enabled: true
       size: 2Gi


### PR DESCRIPTION
This image is only built for amd64