### PR TITLE
Use a statefulset for mongodb

### DIFF
--- a/apps/unifi/values.yaml
+++ b/apps/unifi/values.yaml
@@ -33,6 +33,8 @@ unifi:
     image:
       tag: 5.0.20-debian-11-r0
 
+    useStatefulSet: true
+
     nodeAffinityPreset:
       type: hard
       key: kubernetes.io/arch


### PR DESCRIPTION
It can't even do a rolling restart successfully:
```
{"t":{"$date":"2023-08-26T14:46:24.603+00:00"},"s":"E",  "c":"CONTROL",  "id":20557,   "ctx":"initandlisten","msg":"DBException in initAndListen, terminating","attr":{"error":"DBPathInUse: Unable to lock the lock file: /bitnami/mongodb/data/db/mongod.lock (Resource temporarily unavailable). Another mongod instance is already running on the /bitnami/mongodb/data/db directory"}}
```