### PR TITLE
Rename secret for home assistant acme cert

### DIFF
--- a/apps/home-assistant/values.yaml
+++ b/apps/home-assistant/values.yaml
@@ -55,7 +55,7 @@ ingress:
     tls:
       - hosts:
           - homeassistant.lucyscrib.com
-        secretName: homeassistant-lucys-crib-cert
+        secretName: homeassistant-lucys-crib-cert-acme
 
 onepassword:
   items:


### PR DESCRIPTION
Looks like it was invalid to change the issuer while reusing the existing secret