### PR TITLE
Mount dbus into home assistant container to allow bluetooth access

### DIFF
--- a/apps/home-assistant/values.yaml
+++ b/apps/home-assistant/values.yaml
@@ -37,6 +37,11 @@ persistence:
     readOnly: true
     type: configMap
     name: blueprints-automation
+  dbus:
+    enabled: true
+    mountPath: /run/dbus
+    type: hostPath
+    hostPath: /run/dbus
 
 configmap:
   configuration:


### PR DESCRIPTION
For now every node in the cluster uses the same mount path, so no affinity necessary.