### PR TITLE
Include scenes and scripts created via UI in home assistant config

### DIFF
--- a/apps/home-assistant/values.yaml
+++ b/apps/home-assistant/values.yaml
@@ -56,11 +56,14 @@ configmap:
           trusted_proxies:
             - 10.42.0.0/16
 
+        # Managed via UI
         automation: !include automations.yaml
+        scene: !include scenes.yaml
+        script: !include scripts.yaml
+
+        # Managed via gitops
         automation static: !include static-config/automations.yaml
-
         rest_command: !include static-config/rest_command.yaml
-
         template: !include static-config/templates.yaml
 
 yamlConfigFiles:


### PR DESCRIPTION
Home Assistant still manages these via YAML, but it can't write to the main `configuration.yaml` in order to include those files, so add the includes here.