### PR TITLE
Only schedule home assistant on nodes with the `lucyscrib.com/mdns-reflector` label

### DIFF
--- a/apps/home-assistant/values.yaml
+++ b/apps/home-assistant/values.yaml
@@ -6,6 +6,15 @@ env:
 
 priorityClassName: critical
 
+affinity:
+  nodeAffinity:
+    # This is required for the homekit bridge
+    requiredDuringSchedulingIgnoredDuringExecution:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: lucyscrib.com/mdns-reflector
+              operator: Exists
+
 persistence:
   config:
     enabled: true


### PR DESCRIPTION
All nodes have avahi-daemon running in reflector mode, but alpha doesn't appear to be working, so schedule based on a label.