### PR TITLE
Be more explicit about which k8s service monitors to enable

### DIFF
--- a/apps/prometheus/values.yaml
+++ b/apps/prometheus/values.yaml
@@ -48,5 +48,20 @@ kube-prometheus-stack:
   defaultRules:
     create: false
 
-  kubernetesServiceMonitors:
+  kubeApiServer:
+    enabled: false
+
+  kubeControllerManager:
+    enabled: false
+
+  coreDns:
+    enabled: false
+
+  kubeEtcd:
+    enabled: false
+
+  kubeScheduler:
+    enabled: false
+
+  kubeProxy:
     enabled: false


### PR DESCRIPTION
This will enable the kubelet service monitor so I can track container resource usage.