### PR TITLE
Use `format` field to get correct readings from `electrical_meter`

### DIFF
--- a/apps/rtlamr2mqtt/values.yaml
+++ b/apps/rtlamr2mqtt/values.yaml
@@ -39,8 +39,7 @@ configmap:
             protocol: scm+
             name: electrical_meter
             type: energy
-            multiplier: 0.01
-            precision: 3
+            format: "#####.##"
             unit_of_measurement: Wh
             icon: mdi:gauge
             device_class: energy


### PR DESCRIPTION
`multiplier` and `precision` must have been fields supported by an old version of this tool that worked on the previous home assistant.