### PR TITLE
Configure Prometheus retention

### DIFF
--- a/apps/prometheus/values.yaml
+++ b/apps/prometheus/values.yaml
@@ -1,6 +1,8 @@
 kube-prometheus-stack:
   prometheus:
     prometheusSpec:
+      retention: 14d
+      retentionSize: 45GB
       storageSpec:
         volumeClaimTemplate:
           spec:


### PR DESCRIPTION
Keep 2 weeks of metrics or 45GB