### PR TITLE
Give esphome fewer privileges and remove node affinity

### DIFF
--- a/apps/esphome/values.yaml
+++ b/apps/esphome/values.yaml
@@ -1,9 +1,6 @@
 image:
   repository: ghcr.io/esphome/esphome
 
-securityContext:
-  privileged: true
-
 env:
   USERNAME:
     valueFrom:
@@ -20,11 +17,6 @@ persistence:
   config:
     enabled: true
     size: 10Gi
-  usb:
-    enabled: true
-    mountPath: /dev/bus/usb
-    type: hostPath
-    hostPath: /dev/bus/usb
 
 service:
   main:
@@ -46,14 +38,6 @@ ingress:
       - hosts:
           - esphome.lucyscrib.com
         secretName: esphome-lucys-crib-cert-acme
-
-affinity:
-  nodeAffinity:
-    requiredDuringSchedulingIgnoredDuringExecution:
-      nodeSelectorTerms:
-        - matchExpressions:
-            - key: lucyscrib.com/esphome-flasher
-              operator: Exists
 
 onepassword:
   items:


### PR DESCRIPTION
I can flash devices connected to my machine via the browser, so ESPHome itself doesn't need USB access (and thus doesn't need to be scheduled on one node).