### PR TITLE
Fix invalid Kargo promotion step expression syntax

### DIFF
--- a/apps/kargo-projects/templates/stage.yaml
+++ b/apps/kargo-projects/templates/stage.yaml
@@ -40,7 +40,7 @@ spec:
           as: commit
           config:
             path: ./out
-            message: ${{ "{{" }} task.outputs['update'].commitMessage {{ "}}" }}
+            message: ${{ "{{" }} outputs['update'].commitMessage {{ "}}" }}
         - uses: git-open-pr
           as: open-pr
           config:


### PR DESCRIPTION
The `task` object is only valid in `PromotionTask` resources