### PR TITLE
Tune Kargo to avoid DockerHub rate limits

### DIFF
--- a/apps/kargo-projects/values.yaml
+++ b/apps/kargo-projects/values.yaml
@@ -4,7 +4,8 @@ projects:
       images:
         subscriptions:
           image:
-            ghcr.io/home-assistant/home-assistant: {}
+            ghcr.io/home-assistant/home-assistant:
+              discoveryLimit: 5
 
     promotion:
       helmAppVersion: {}
@@ -14,7 +15,8 @@ projects:
       images:
         subscriptions:
           image:
-            zwavejs/zwave-js-ui: {}
+            zwavejs/zwave-js-ui:
+              discoveryLimit: 5
 
     promotion:
       helmAppVersion: {}

--- a/apps/kargo/values.yaml
+++ b/apps/kargo/values.yaml
@@ -31,18 +31,9 @@ kargo:
         selfSignedCert: false
 
   controller:
-    # TODO
-    gitClient:
-      ## @param controller.gitClient.name Specifies the name of the Kargo controller (used when authoring Git commits).
-      name: "Kargo"
-      ## @param controller.gitClient.email Specifies the email of the Kargo controller (used when authoring Git commits).
-      email: "no-reply@kargo.io"
-
-      signingKeySecret:
-        ## @param controller.gitClient.signingKeySecret.name Specifies the name of an existing `Secret` which contains the Git user's signing key. The value should be accessible under `.data.signingKey` in the same namespace as Kargo. When the signing key is a GPG key, the GPG key's name and email address identity must match the values defined for `controller.gitClient.name` and `controller.gitClient.email`.
-        name: ""
-        ## @param controller.gitClient.signingKeySecret.type Specifies the type of the signing key. The currently supported and default option is `gpg`.
-        type: ""
+    reconcilers:
+      warehouses:
+        minReconciliationInterval: 30m
 
 onepassword:
   items:


### PR DESCRIPTION
* Increase reconcile interval so polls are less frequent
* Decrease discovery limit so fewer tags are polled