### PR TITLE
Use explicit dockerhub registry domain for zwave-js-ui

### DIFF
--- a/apps/kargo-projects/values.yaml
+++ b/apps/kargo-projects/values.yaml
@@ -15,7 +15,7 @@ projects:
       images:
         subscriptions:
           image:
-            zwavejs/zwave-js-ui:
+            docker.io/zwavejs/zwave-js-ui:
               discoveryLimit: 5
 
     promotion:


### PR DESCRIPTION
I think this is necessary to make the dockerhub creds work