### PR TITLE
Enable Kargo for rtlamr2mqtt

### DIFF
--- a/apps/kargo-projects/values.yaml
+++ b/apps/kargo-projects/values.yaml
@@ -32,6 +32,18 @@ projects:
     promotion:
       helmAppVersion: {}
 
+  rtlamr2mqtt:
+    warehouses:
+      images:
+        subscriptions:
+          image:
+            docker.io/allangood/rtlamr2mqtt:
+              discoveryLimit: 5
+              semverConstraint: ^2
+
+    promotion:
+      helmAppVersion: {}
+
   zwave-js-ui:
     warehouses:
       images:


### PR DESCRIPTION
Creator recently did a full rewrite of the app, so pin to the 2 major version