### PR TITLE
feat: migrate remaining apps from onepassword operator to external-secrets

### DIFF
--- a/apps/cloudflare-tunnel/Chart.lock
+++ b/apps/cloudflare-tunnel/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
-- name: onepassword
-  repository: file://../../charts/onepassword
+- name: external-secrets
+  repository: file://../../charts/external-secrets
   version: 0.1.0
-digest: sha256:2aef75ca6f923640064ce1645814bd3afd325f4e0e52e6dd5e70b6f20c5b0dd7
-generated: "2023-09-04T10:59:14.929584-04:00"
+digest: sha256:0dbd24b02907940c3797cad2a7a1a787dc3f16f971e257f24336efca831c6ab4
+generated: "2026-04-18T10:21:20.536779-04:00"

--- a/apps/cloudflare-tunnel/Chart.yaml
+++ b/apps/cloudflare-tunnel/Chart.yaml
@@ -6,6 +6,6 @@ version: 0.1.0
 appVersion: 2026.1.1
 
 dependencies:
-  - name: onepassword
-    repository: file://../../charts/onepassword
+  - name: external-secrets
+    repository: file://../../charts/external-secrets
     version: 0.1.0

--- a/apps/cloudflare-tunnel/values.yaml
+++ b/apps/cloudflare-tunnel/values.yaml
@@ -61,12 +61,18 @@ tolerations: []
 
 affinity: {}
 
-onepassword:
-  items:
-    lucyscrib-tunnel-creds:
-      enabled: true
-      item: cloudflared-lucyscrib-tunnel-creds
-
-    lucyscrib-tunnel-origin:
-      enabled: true
-      item: cloudflared-lucyscrib-tunnel-origin
+external-secrets:
+  onepassword:
+    secrets:
+      lucyscrib-tunnel-creds:
+        enabled: true
+        keys:
+          credential:
+            item: cloudflared-lucyscrib-tunnel-creds
+            field: credential
+      lucyscrib-tunnel-origin:
+        enabled: true
+        keys:
+          cert.pem:
+            item: cloudflared-lucyscrib-tunnel-origin
+            field: cert.pem

--- a/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
@@ -1,12 +1,30 @@
 {{- range $projectName, $project := .Values.projects }}
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: dockerhub-creds
   namespace: {{ include "kargo.projectName" $projectName }}
   labels:
     kargo.akuity.io/cred-type: image
 spec:
-  itemPath: vaults/Homelab/items/kargo-dockerhub-creds
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password-homelab
+  target:
+    creationPolicy: Owner
+    name: dockerhub-creds
+  data:
+    - secretKey: username
+      remoteRef:
+        key: kargo-dockerhub-creds/username
+    - secretKey: password
+      remoteRef:
+        key: kargo-dockerhub-creds/password
+    - secretKey: repoURL
+      remoteRef:
+        key: kargo-dockerhub-creds/repoURL
+    - secretKey: repoURLIsRegex
+      remoteRef:
+        key: kargo-dockerhub-creds/repoURLIsRegex
 {{- end }}

--- a/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
@@ -5,8 +5,6 @@ kind: ExternalSecret
 metadata:
   name: dockerhub-creds
   namespace: {{ include "kargo.projectName" $projectName }}
-  labels:
-    kargo.akuity.io/cred-type: image
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
@@ -14,6 +12,10 @@ spec:
   target:
     creationPolicy: Owner
     name: dockerhub-creds
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: image
   data:
     - secretKey: username
       remoteRef:

--- a/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-dockerhub-creds.yaml
@@ -16,6 +16,9 @@ spec:
       metadata:
         labels:
           kargo.akuity.io/cred-type: image
+      data:
+        repoURL: docker.io
+        repoURLIsRegex: "true"
   data:
     - secretKey: username
       remoteRef:
@@ -23,10 +26,4 @@ spec:
     - secretKey: password
       remoteRef:
         key: kargo-dockerhub-creds/password
-    - secretKey: repoURL
-      remoteRef:
-        key: kargo-dockerhub-creds/repoURL
-    - secretKey: repoURLIsRegex
-      remoteRef:
-        key: kargo-dockerhub-creds/repoURLIsRegex
 {{- end }}

--- a/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
@@ -1,12 +1,30 @@
 {{- range $projectName, $project := .Values.projects }}
 ---
-apiVersion: onepassword.com/v1
-kind: OnePasswordItem
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
 metadata:
   name: github-app-creds
   namespace: {{ include "kargo.projectName" $projectName }}
   labels:
     kargo.akuity.io/cred-type: git
 spec:
-  itemPath: vaults/Homelab/items/kargo-github-app-creds
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: 1password-homelab
+  target:
+    creationPolicy: Owner
+    name: github-app-creds
+  data:
+    - secretKey: githubAppID
+      remoteRef:
+        key: kargo-github-app-creds/githubAppID
+    - secretKey: githubAppInstallationID
+      remoteRef:
+        key: kargo-github-app-creds/githubAppInstallationID
+    - secretKey: githubAppPrivateKey
+      remoteRef:
+        key: kargo-github-app-creds/githubAppPrivateKey
+    - secretKey: repoURL
+      remoteRef:
+        key: kargo-github-app-creds/repoURL
 {{- end }}

--- a/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
@@ -5,8 +5,6 @@ kind: ExternalSecret
 metadata:
   name: github-app-creds
   namespace: {{ include "kargo.projectName" $projectName }}
-  labels:
-    kargo.akuity.io/cred-type: git
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
@@ -14,6 +12,10 @@ spec:
   target:
     creationPolicy: Owner
     name: github-app-creds
+    template:
+      metadata:
+        labels:
+          kargo.akuity.io/cred-type: git
   data:
     - secretKey: githubAppID
       remoteRef:

--- a/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
+++ b/apps/kargo-projects/templates/onepassword-item-github-app-creds.yaml
@@ -16,6 +16,8 @@ spec:
       metadata:
         labels:
           kargo.akuity.io/cred-type: git
+      data:
+        repoURL: https://github.com/apt-itude/homelab-kubernetes.git
   data:
     - secretKey: githubAppID
       remoteRef:
@@ -26,7 +28,4 @@ spec:
     - secretKey: githubAppPrivateKey
       remoteRef:
         key: kargo-github-app-creds/githubAppPrivateKey
-    - secretKey: repoURL
-      remoteRef:
-        key: kargo-github-app-creds/repoURL
 {{- end }}

--- a/apps/kargo/Chart.lock
+++ b/apps/kargo/Chart.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: kargo
   repository: oci://ghcr.io/akuity/kargo-charts
   version: 1.6.1
-- name: onepassword
-  repository: file://../../charts/onepassword
+- name: external-secrets
+  repository: file://../../charts/external-secrets
   version: 0.1.0
-digest: sha256:1154aac63f446f394c2513529288d8869bfc78c339b8323273254935273ae831
-generated: "2025-07-26T08:39:56.530512-04:00"
+digest: sha256:f7ac40bd4d48b3e15477e90dd2a2bce18da2410fb734949eecf41bc584ec2c37
+generated: "2026-04-18T10:21:48.576145-04:00"

--- a/apps/kargo/Chart.yaml
+++ b/apps/kargo/Chart.yaml
@@ -9,6 +9,6 @@ dependencies:
     repository: oci://ghcr.io/akuity/kargo-charts
     version: 1.6.1
 
-  - name: onepassword
-    repository: file://../../charts/onepassword
+  - name: external-secrets
+    repository: file://../../charts/external-secrets
     version: 0.1.0

--- a/apps/kargo/values.yaml
+++ b/apps/kargo/values.yaml
@@ -35,8 +35,15 @@ kargo:
       warehouses:
         minReconciliationInterval: 30m
 
-onepassword:
-  items:
-    admin-creds:
-      enabled: true
-      item: kargo-admin-creds
+external-secrets:
+  onepassword:
+    secrets:
+      admin-creds:
+        enabled: true
+        keys:
+          ADMIN_ACCOUNT_PASSWORD_HASH:
+            item: kargo-admin-creds
+            field: ADMIN_ACCOUNT_PASSWORD_HASH
+          ADMIN_ACCOUNT_TOKEN_SIGNING_KEY:
+            item: kargo-admin-creds
+            field: ADMIN_ACCOUNT_TOKEN_SIGNING_KEY

--- a/apps/mosquitto/Chart.lock
+++ b/apps/mosquitto/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 4.5.2
-- name: onepassword
-  repository: file://../../charts/onepassword
-  version: 0.1.0
-digest: sha256:9289d792ddf507c9246f44ccb739883a1bb5cf7eee748d623df23d8fd44d388e
-generated: "2023-09-08T17:15:55.332366-04:00"
+digest: sha256:408d12aa9bbce6dfd4ced5c2586d92dfa518821e01823081fa9a141243b3160c
+generated: "2026-04-18T10:12:59.78459-04:00"

--- a/apps/mosquitto/Chart.yaml
+++ b/apps/mosquitto/Chart.yaml
@@ -9,7 +9,3 @@ dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
     version: 4.5.2
-
-  - name: onepassword
-    repository: file://../../charts/onepassword
-    version: 0.1.0

--- a/apps/rtlamr2mqtt/Chart.lock
+++ b/apps/rtlamr2mqtt/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 4.5.2
-- name: onepassword
-  repository: file://../../charts/onepassword
-  version: 0.1.0
-digest: sha256:9289d792ddf507c9246f44ccb739883a1bb5cf7eee748d623df23d8fd44d388e
-generated: "2023-09-08T18:16:56.727499-04:00"
+digest: sha256:408d12aa9bbce6dfd4ced5c2586d92dfa518821e01823081fa9a141243b3160c
+generated: "2026-04-18T10:13:07.134053-04:00"

--- a/apps/rtlamr2mqtt/Chart.yaml
+++ b/apps/rtlamr2mqtt/Chart.yaml
@@ -9,7 +9,3 @@ dependencies:
   - name: common
     repository: https://library-charts.k8s-at-home.com
     version: 4.5.2
-
-  - name: onepassword
-    repository: file://../../charts/onepassword
-    version: 0.1.0

--- a/apps/zwave-js-ui/Chart.lock
+++ b/apps/zwave-js-ui/Chart.lock
@@ -2,8 +2,8 @@ dependencies:
 - name: common
   repository: https://library-charts.k8s-at-home.com
   version: 4.5.2
-- name: onepassword
-  repository: file://../../charts/onepassword
+- name: external-secrets
+  repository: file://../../charts/external-secrets
   version: 0.1.0
-digest: sha256:9289d792ddf507c9246f44ccb739883a1bb5cf7eee748d623df23d8fd44d388e
-generated: "2023-09-04T10:45:44.162039-04:00"
+digest: sha256:4bbee28faa715f6505e4f4437603b177a177e7a6d232dabba86fc967b8b6635f
+generated: "2026-04-18T10:20:52.707926-04:00"

--- a/apps/zwave-js-ui/Chart.yaml
+++ b/apps/zwave-js-ui/Chart.yaml
@@ -10,6 +10,6 @@ dependencies:
     repository: https://library-charts.k8s-at-home.com
     version: 4.5.2
 
-  - name: onepassword
-    repository: file://../../charts/onepassword
+  - name: external-secrets
+    repository: file://../../charts/external-secrets
     version: 0.1.0

--- a/apps/zwave-js-ui/values.yaml
+++ b/apps/zwave-js-ui/values.yaml
@@ -138,11 +138,30 @@ ingress:
           - zwave-server.lucyscrib.com
         secretName: zwave-server-lucys-crib-cert-acme
 
-onepassword:
-  items:
-    zwave:
-      enabled: true
-      item: ZWave
-    zwave-default-creds:
-      enabled: true
-      item: zwave-js-ui
+external-secrets:
+  onepassword:
+    secrets:
+      zwave:
+        enabled: true
+        keys:
+          KEY_S0_Legacy:
+            item: ZWave
+            field: KEY_S0_Legacy
+          KEY_S2_Unauthenticated:
+            item: ZWave
+            field: KEY_S2_Unauthenticated
+          KEY_S2_Authenticated:
+            item: ZWave
+            field: KEY_S2_Authenticated
+          KEY_S2_AccessControl:
+            item: ZWave
+            field: KEY_S2_AccessControl
+      zwave-default-creds:
+        enabled: true
+        keys:
+          username:
+            item: zwave-js-ui
+            field: username
+          password:
+            item: zwave-js-ui
+            field: password


### PR DESCRIPTION
## Summary

- Replaces `OnePasswordItem` CRDs with `ExternalSecret` resources across all remaining apps using the OnePassword Kubernetes operator
- Migrated apps with active secrets: `zwave-js-ui`, `cloudflare-tunnel`, `kargo`, `kargo-projects`
- Removed unused `onepassword` chart dependency from `mosquitto` and `rtlamr2mqtt` (no active items)
- The `kargo-projects` templates now generate per-namespace `ExternalSecret` resources (one per kargo project) instead of `OnePasswordItem` resources

## Validations

- Run `helm template apps/<app>` to confirm `ExternalSecret` resources render and no `OnePasswordItem` resources remain