### PR TITLE
Fix kargo project creds after external secret migration

### DIFF
--- a/apps/kargo-projects/templates/externalsecret-dockerhub-creds.yaml
+++ b/apps/kargo-projects/templates/externalsecret-dockerhub-creds.yaml
@@ -14,6 +14,8 @@ spec:
     creationPolicy: Owner
     name: dockerhub-creds
     template:
+      engineVersion: v2
+      mergePolicy: Merge
       metadata:
         labels:
           kargo.akuity.io/cred-type: image

--- a/apps/kargo-projects/templates/externalsecret-github-app-creds.yaml
+++ b/apps/kargo-projects/templates/externalsecret-github-app-creds.yaml
@@ -14,6 +14,8 @@ spec:
     creationPolicy: Owner
     name: github-app-creds
     template:
+      engineVersion: v2
+      mergePolicy: Merge
       metadata:
         labels:
           kargo.akuity.io/cred-type: git


### PR DESCRIPTION
Default policy is replace, so the actual secret values were overwritten