### PR TITLE
Migrate from deprecated allowTags Kargo Warehouse config

### DIFF
--- a/apps/kargo-projects/values.yaml
+++ b/apps/kargo-projects/values.yaml
@@ -7,7 +7,8 @@ projects:
             docker.io/cloudflare/cloudflared:
               discoveryLimit: 5
               # No pre-releases
-              allowTags: ^\d{4}.\d{1,2}.\d+$
+              allowTagsRegexes:
+                - ^\d{4}.\d{1,2}.\d+$
     promotion:
       helmAppVersion: {}
 
@@ -19,7 +20,8 @@ projects:
             ghcr.io/esphome/esphome:
               discoveryLimit: 5
               # No pre-releases
-              allowTags: ^\d{4}.\d{1,2}.\d+$
+              allowTagsRegexes:
+                - ^\d{4}.\d{1,2}.\d+$
     promotion:
       helmAppVersion: {}
 
@@ -31,7 +33,8 @@ projects:
             ghcr.io/home-assistant/home-assistant:
               discoveryLimit: 5
               # No pre-releases
-              allowTags: ^\d{4}.\d{1,2}.\d+$
+              allowTagsRegexes:
+                - ^\d{4}.\d{1,2}.\d+$
     promotion:
       helmAppVersion: {}
 


### PR DESCRIPTION
Deprecated in 1.9: https://docs.kargo.io/release-notes/v1.9.0#new-deprecations